### PR TITLE
Fix duplicate day issue

### DIFF
--- a/owm.controller.js
+++ b/owm.controller.js
@@ -9,21 +9,14 @@
 					console.log("Processing OWM widget forecast");
 					try {
 						var today = new Date();
-						var nextDay = new Date();
-
+						var hoursToNoon = (24 - today.getHours()) + 12;
 						for (var day = 0; day < 4; day++) {
-							today = new Date();
-                                                        nextDay = new Date();
-							nextDay.setDate(today.getDate() + day);
-							nextDay.setHours(12);
-							var diffHours = Math.ceil(Math.abs(today.getTime() - nextDay.getTime()) / (1000 * 3600));
-							setForecastItems(day, getClosest(diffHours));
+							setForecastItems(day, getClosest(hoursToNoon + (day * 24)));
 						}
-
 					} catch (err) {
 						console.log("Error during OWM widget: " + err)
 					}
-				}
+                                }
 
 				// Set forecast values for particular day
 				function setForecastItems(day, hour) {


### PR DESCRIPTION
This calculates the number of hours to the next day at noon, and then adds 24*day for the next 3 days. I'm not exactly sure where the original code is going wrong, but we can avoid doing math on Date objects completely since we only care about the number of hours until the next day at noon.